### PR TITLE
Remove explicit call to Fixnum class

### DIFF
--- a/lib/oxcelix.rb
+++ b/lib/oxcelix.rb
@@ -33,7 +33,7 @@ class Matrix
   end
 end
 
-class Fixnum
+class Integer
   # Returns the column name corresponding to the given number. e.g: 1.col_name => 'B'
   # @return [String]
   def col_name


### PR DESCRIPTION
This fixes the deprecation warning seen in ruby 2.4.0 + 
#11 